### PR TITLE
fix: prevent too strict dependencies in built lib's package.json

### DIFF
--- a/libs/ng-utils/package.json
+++ b/libs/ng-utils/package.json
@@ -7,5 +7,14 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Adroit-Group/ng-tools"
-  }
+  },
+  "peerDependencies": {
+    "@angular/common": ">=15.0.0",
+    "@angular/core": ">=15.0.0",
+    "@angular/cdk": ">=15.0.0",
+    "@angular/platform-browser": ">=15.0.0",
+    "@angular/forms": ">=15.0.0",
+    "rxjs": ">=6.5.3"
+  },
+  "sideEffects": false
 }

--- a/libs/ng-utils/project.json
+++ b/libs/ng-utils/project.json
@@ -9,7 +9,8 @@
       "executor": "@nrwl/angular:package",
       "outputs": ["dist/libs/ng-utils"],
       "options": {
-        "project": "libs/ng-utils/ng-package.json"
+        "project": "libs/ng-utils/ng-package.json",
+        "updateBuildableProjectDepsInPackageJson": false
       },
       "configurations": {
         "production": {


### PR DESCRIPTION
The automatic nx dependency collection adds unnecessary and too strict dependencies and peer dependencies to the built lib's package.json which causes difficulties during the usage of the library.
Instead we should explicitly state the dependencies and disable nx's automatic override function